### PR TITLE
Allow items to be placed on the right-hand side of the image even on a small screen.

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,8 @@
+.que .ddmarker  {
+    display: inline-block;
+    padding-right: 5em;
+}
+
 .que.ddmarker .qtext {
     margin-bottom: 0.5em;
     display: block;


### PR DESCRIPTION
A couple of suggested CSS changes to address the issue just raised in #28 

This change to set .ddmarker to inline-block so width is set to contents rather than container and adds some additional padding on the right 
